### PR TITLE
Upgrade Gradle Wrapper to 7.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/versions.properties
+++ b/versions.properties
@@ -25,7 +25,7 @@ version.io.gitlab.arturbosch.detekt..detekt-gradle-plugin=1.17.1
 
 version.kotest=4.5.0
 
-version.kotlin=1.4.32
+version.kotlin=1.5.30
 
 version.org.danilopianini..git-sensitive-semantic-versioning=0.3.0
 


### PR DESCRIPTION
This pull request upgrades the Gradle wrapper in project 
from 7.1.1 to 7.2.                       