### PR TITLE
Include Yoki project on readme usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ it will provide useful use cases for newcomers to look at.
 
 ### Kotlin-multiplatform
 * [**Template for Kotlin Multiplatform projects**](https://github.com/DanySK/Template-for-Kotlin-Multiplatform-Projects): a project template for quickly spawning new Kotlin-multiplatform projects
+* [**yoki**](https://github.com/DevNatan/yoki): Kotlin Docker Remote API client
 
 ## Contributing to the project
 


### PR DESCRIPTION
Thanks to this library I skipped 48^3 pages of explanation of how to publish to Maven Central using Gradle and an hour of StackOverflow thx!!! 👍🏽