### PR TITLE
feat: allow exporting Nexus repository IDs and publishing artifacts to an open Nexus staging repository

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -160,9 +160,9 @@ jobs:
           deploy-command: |
             COMMAND='./gradlew --include-build ../publish-on-central createStagingRepositoryOnMavenCentral --parallel'
             $(echo "$COMMAND") || $(echo "$COMMAND") || $(echo "$COMMAND")
-            REPO_IDS='cat build/staging-repo-ids.properties'
-            $(echo "$REPO_IDS") || $(echo "$REPO_IDS") || $(echo "$REPO_IDS")
-          working-directory: kt-mp
+            [[ -e build/staging-repo-ids.properties ]]
+            [[ $(cat build/staging-repo-ids.properties) =~ "^MavenCentral=(.*)$" ]]
+          working-directory: kt-mp-multi-stage
           should-run-codecov: false
           should-deploy: true
           maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -161,7 +161,8 @@ jobs:
             COMMAND='./gradlew --include-build ../publish-on-central createStagingRepositoryOnMavenCentral --parallel'
             $(echo "$COMMAND") || $(echo "$COMMAND") || $(echo "$COMMAND")
             [[ -e build/staging-repo-ids.properties ]]
-            [[ $(cat build/staging-repo-ids.properties) =~ "^MavenCentral=(.*)$" ]]
+            [[ "$(wc -l build/staging-repo-ids.properties)" =~ "^1 .*" ]]
+            [[ "$(cat build/staging-repo-ids.properties)" =~ '^MavenCentral=\w+-\d+$' ]]
           working-directory: kt-mp-multi-stage
           should-run-codecov: false
           should-deploy: true

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -49,7 +49,7 @@ jobs:
           )
           echo "Scripts update line: \"$USES\""
           echo "Computed version: \"${USES#*@}\""
-          echo "::set-output name=version::${USES#*@}"
+          echo "version=${USES#*@}" >> $GITHUB_OUTPUT
       - name: Checkout Alchemist ${{ steps.alchemist.outputs.version }}
         uses: actions/checkout@v3.3.0
         with:
@@ -94,7 +94,7 @@ jobs:
           )
           echo "Scripts update line: \"$USES\""
           echo "Computed version: \"${USES#*@}\""
-          echo "::set-output name=version::${USES#*@}"
+          echo "version=${USES#*@}" >> $GITHUB_OUTPUT
       - name: Checkout Template-for-Kotlin-Multiplatform-Projects ${{ steps.versiontrick.outputs.version }}
         uses: actions/checkout@v3.3.0
         with:
@@ -115,6 +115,53 @@ jobs:
           deploy-command: |
             COMMAND='./gradlew --include-build ../publish-on-central uploadAllPublicationsToMavenCentralNexus closeStagingRepositoryOnMavenCentral --parallel'
             $(echo "$COMMAND") || $(echo "$COMMAND") || $(echo "$COMMAND")
+          working-directory: kt-mp
+          should-run-codecov: false
+          should-deploy: true
+          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          signing-key: ${{ secrets.SIGNING_KEY }}
+          signing-password: ${{ secrets.SIGNING_PASSWORD }}
+  test-multi-stage-deployment:
+    runs-on: ubuntu-latest
+    if: >-
+      !github.event.repository.fork
+      && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    steps:
+      - name: Compute the version of the target test project
+        id: versiontrick
+        shell: bash
+        run: |
+          # Idea: the regex matcher of Renovate keeps this string up to date automatically
+          # The version is extracted and used to access the correct version of the scripts
+          USES=$(cat <<TRICK_RENOVATE
+          - uses: DanySK/template-for-kotlin-multiplatform-projects@0.1.7
+          TRICK_RENOVATE
+          )
+          echo "Scripts update line: \"$USES\""
+          echo "Computed version: \"${USES#*@}\""
+          echo "version=${USES#*@}" >> $GITHUB_OUTPUT
+      - name: Checkout Template-for-Kotlin-Multiplatform-Projects ${{ steps.versiontrick.outputs.version }}
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: '0'
+          path: 'kt-mp-multi-stage'
+          ref: "${{ steps.versiontrick.outputs.version }}"
+          repository: 'DanySK/Template-for-Kotlin-Multiplatform-Projects'
+          submodules: 'recursive'
+      - name: Checkout publish-on-central
+        uses: actions/checkout@v3.3.0
+        with:
+          path: 'publish-on-central'
+      - name: Dry-deploy
+        uses: DanySK/build-check-deploy-gradle-action@2.1.21
+        with:
+          build-command: true
+          check-command: true
+          deploy-command: |
+            COMMAND='./gradlew --include-build ../publish-on-central createStagingRepositoryOnMavenCentral --parallel'
+            $(echo "$COMMAND") || $(echo "$COMMAND") || $(echo "$COMMAND")
+            REPO_IDS='cat build/staging-repo-ids.properties'
+            $(echo "$REPO_IDS") || $(echo "$REPO_IDS") || $(echo "$REPO_IDS")
           working-directory: kt-mp
           should-run-codecov: false
           should-deploy: true

--- a/README.md
+++ b/README.md
@@ -292,7 +292,9 @@ jobs:
       - name: Create staging repository
         id: createStagingRepository
         # This step creates a staging repository on Maven Central and exports the staging repository ID as an output
-        run: ./gradlew createStagingRepositoryOnMavenCentral
+        run: |
+          ./gradlew createStagingRepositoryOnMavenCentral
+          cat build/staging-repo-ids.properties >> $GITHUB_OUTPUT
           
   release:
     needs: build
@@ -306,7 +308,7 @@ jobs:
           java-version: 11
       - name: Use staging repository
         # Use the staging repository ID exported by the previous job to upload artifacts to the same staging repository
-        run: ./gradlew -PstagingRepositoryId=${{ needs.build.outputs.repositoryId }} uploadAllPublicationsToMavenCentralNexus
+        run: ./gradlew -PstagingRepositoryId=${{ needs.build.outputs.MavenCentral }} uploadAllPublicationsToMavenCentralNexus
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -268,11 +268,10 @@ flowchart LR
 
 ## Multi-stage upload
 
-This plugin, during the execution of the `createStagingRepositoryOn[Repo]` task, exports the staging repository ID in
-the format `[Repo]StagingRepositoryId` as an output of the step.
+This plugin, during the execution of the `createStagingRepositoryOn[Repo]` task, exports a file in
+`build/staging-repo-ids.properties` containing the staging repository ID in the format `[Repo]=<repo-id>`.
 
-Using this output, it is possible, from other jobs, to upload artifacts to the same staging repository by using the
-`stagingRepositoryId` gradle property.
+This file can be used to export all the repository IDs to the environment, and then use them in other jobs.
 
 An example below shows how to use this feature to upload artifacts to a staging repository from a different job.
 
@@ -295,7 +294,7 @@ jobs:
         run: |
           ./gradlew createStagingRepositoryOnMavenCentral
           cat build/staging-repo-ids.properties >> $GITHUB_OUTPUT
-          
+
   release:
     needs: build
     matrix:

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/Configuration.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/Configuration.kt
@@ -105,6 +105,17 @@ private fun Project.configureNexusRepository(repoToConfigure: Repository, nexusU
         doLast {
             rootProject.warnIfCredentialsAreMissing(repoToConfigure)
             nexusClient.nexusClient.repoUrl // triggers the initialization of a repository
+            // Write the staging repository ID to the Github env if on CI
+            if (System.getenv("CI") == true.toString()) {
+                exec {
+                    it.commandLine(
+                        "echo",
+                        "${repoToConfigure.name}StagingRepositoryId=${nexusClient.nexusClient.repoId}",
+                        ">>",
+                        "\$GITHUB_OUTPUT"
+                    )
+                }
+            }
         }
         group = PublishingPlugin.PUBLISH_TASK_GROUP
         description = "Creates a new Nexus staging repository on ${repoToConfigure.name}."

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/Configuration.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/Configuration.kt
@@ -105,17 +105,10 @@ private fun Project.configureNexusRepository(repoToConfigure: Repository, nexusU
         doLast {
             rootProject.warnIfCredentialsAreMissing(repoToConfigure)
             nexusClient.nexusClient.repoUrl // triggers the initialization of a repository
-            // Write the staging repository ID to the Github env if on CI
-            if (System.getenv("CI") == true.toString()) {
-                exec {
-                    it.commandLine(
-                        "echo",
-                        "${repoToConfigure.name}StagingRepositoryId=${nexusClient.nexusClient.repoId}",
-                        ">>",
-                        "\$GITHUB_OUTPUT"
-                    )
-                }
-            }
+            // Write the staging repository ID to build/staging-repo-ids.properties file
+            project.buildDir.resolve("staging-repo-ids.properties").appendText(
+                "${repoToConfigure.name}=${nexusClient.nexusClient.repoId}" + System.lineSeparator()
+            )
         }
         group = PublishingPlugin.PUBLISH_TASK_GROUP
         description = "Creates a new Nexus staging repository on ${repoToConfigure.name}."

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/NexusStatefulOperation.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/NexusStatefulOperation.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.internal.impldep.com.google.api.client.http.HttpStatusCodes
-import org.gradle.kotlin.dsl.provideDelegate
 import java.net.URI
 import java.time.Duration
 

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/NexusStatefulOperation.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/NexusStatefulOperation.kt
@@ -60,9 +60,10 @@ data class NexusStatefulOperation(
      * Lazily computed staging repository descriptor.
      */
     val stagingRepository: StagingRepositoryDescriptor by lazy {
-        project.properties["nexusStagingRepositoryId"]?.let {
+        project.properties["stagingRepositoryId"]?.let {
             project.logger.lifecycle("Using existing staging repository {}", it)
-            return@lazy StagingRepositoryDescriptor(project.uri(nexusUrl), it as String)
+            val stagingRepo = client.getStagingRepositoryStateById(it as String)
+            return@lazy StagingRepositoryDescriptor(project.uri(nexusUrl), stagingRepo.id)
         } ?: run {
             project.logger.lifecycle("Creating repository for profile id {} on Nexus at {}", stagingProfile, nexusUrl)
             client.createStagingRepository(


### PR DESCRIPTION
This PR aims to improve the plugin to better manage the upload artifacts in different stages.

## Rationale

Sometimes could be useful to configure the plugin to publish artifacts to a specific staging repository.
For example, in Kotlin KMP projects, each OS runner should publish all the relative artifacts to the same staging repository.
At the moment, this problem is solved by running all the publishing tasks on a `macOS` runner since can cross-compile for all the other platforms (iOS, win, Linux, etc.). This causes the `macOS` runner to run for a very long time ~45 minutes which could cause a high cost.

At the moment, this plugin creates a new staging repository for each run, causing the creation of a separate staging repository for each runner OS despite all the artifacts belonging to a single release.

The feature introduced in this PR tries to enable you to specify which repository should be used to upload the artifacts by declaring the `nexusStagingRepositoryId` gradle property.

In this way, we could define a CI workflow as follow:
```mermaid
graph TD
  A[Create staging repository] -- repositoryId --> B[Linux Runner]
  A -- repositoryId --> C[macOS Runner]
  A -- repositoryId --> D[Windows Runner]
  B --> T1[...]
  C --> T2[...]
  D --> T3[...]
```

A job is responsible to create the staging repository. Then, the repo id is shared with each runner so that all the artifacts will be uploaded to the right repository.

If I have not missed anything, this should restrict the responsibility to each runner (host platform) to release the corresponding target platform into the shared staging repository. Moreover, this has the advantage of not overloading the `macOS` runner, turning into an economic saving.

If I have missed something or you have more ideas on how to improve this aspect, let me know!
