### PR TITLE
fix: do not fail on closure of already closed Nexus repositories

### DIFF
--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/Configuration.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/Configuration.kt
@@ -125,12 +125,12 @@ private fun Project.configureNexusRepository(repoToConfigure: Repository, nexusU
         "closeStagingRepositoryOn${repoToConfigure.name}"
     ) {
         doLast {
-            val currentStagingRepoState =
-                nexusClient.nexusClient.client.getStagingRepositoryStateById(nexusClient.nexusClient.repoId)
-            if (currentStagingRepoState.state == StagingRepository.State.CLOSED) {
-                logger.warn("The staging repository is already closed. Skipping.")
-            } else {
-                nexusClient.nexusClient.close()
+            with(nexusClient.nexusClient) {
+                when(client.getStagingRepositoryStateById(repoId)) {
+                    StagingRepository.State.CLOSED ->
+                        logger.warn("The staging repository is already closed. Skipping.")
+                    else -> close()
+                }
             }
         }
         dependsOn(createStagingRepository)

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/Configuration.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/Configuration.kt
@@ -1,5 +1,6 @@
 package org.danilopianini.gradle.mavencentral
 
+import io.github.gradlenexus.publishplugin.internal.StagingRepository
 import org.danilopianini.gradle.mavencentral.ProjectExtensions.registerTaskIfNeeded
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -123,7 +124,15 @@ private fun Project.configureNexusRepository(repoToConfigure: Repository, nexusU
     val closeStagingRepository = rootProject.registerTaskIfNeeded<DefaultTask>(
         "closeStagingRepositoryOn${repoToConfigure.name}"
     ) {
-        doLast { nexusClient.nexusClient.close() }
+        doLast {
+            val currentStagingRepoState =
+                nexusClient.nexusClient.client.getStagingRepositoryStateById(nexusClient.nexusClient.repoId)
+            if (currentStagingRepoState.state == StagingRepository.State.CLOSED) {
+                logger.warn("The staging repository is already closed. Skipping.")
+            } else {
+                nexusClient.nexusClient.close()
+            }
+        }
         dependsOn(createStagingRepository)
         mustRunAfter(uploadAllPublications)
         group = PublishingPlugin.PUBLISH_TASK_GROUP

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/Configuration.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/Configuration.kt
@@ -126,7 +126,7 @@ private fun Project.configureNexusRepository(repoToConfigure: Repository, nexusU
     ) {
         doLast {
             with(nexusClient.nexusClient) {
-                when(client.getStagingRepositoryStateById(repoId)) {
+                when (client.getStagingRepositoryStateById(repoId).state) {
                     StagingRepository.State.CLOSED ->
                         logger.warn("The staging repository is already closed. Skipping.")
                     else -> close()


### PR DESCRIPTION
When using the plugin in a "multi-stage" deployment, on the final job (using semantic-release) the `releaseStagingRepositoryOnMavenCentral` task is called. This task depends on the `closeStagingrepositoryOnMavenCentral`, but since the staging repo is closed on the previous CI job (the job that tries to upload and close the staging repo), the staging repo will be closed twice producing the following errors:
```
:closeStagingRepositoryOnMavenCentral FAILED
Failed to close staging repository, server at https://s01.oss.sonatype.org/service/local/ responded with status code 500, body: {"errors":[{"id":"*","msg":"Unhandled: Repository: itnicolasfarabegoli-1207 has invalid state: closed"}]}
```

This PR introduces a check in the `closeStagingrepositoryOnMavenCentral` that if the repository is already closed, skip the closing action, raising a warning saying that the closing task is skipped

Let me know how does it sound :)