### PR TITLE
fix: prioritize Dokka v2 tasks over Dokka v1, if both exist

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dokka = "2.1.0"
+dokka = "2.0.0"
 kotest = "6.0.7"
 kotlin = "2.3.0"
 testkit = "0.9.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dokka = "2.0.0"
+dokka = "2.1.0"
 kotest = "6.0.7"
 kotlin = "2.3.0"
 testkit = "0.9.0"

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/PublishOnCentral.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/PublishOnCentral.kt
@@ -24,7 +24,6 @@ import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
-import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.dokka.gradle.tasks.DokkaGenerateTask
 
 /**
@@ -118,9 +117,13 @@ class PublishOnCentral : Plugin<Project> {
             project.tasks.withType<Javadoc>().configureEach { it.enabled = false }
             project.tasks.withType<Jar>().matching { "javadoc" in it.name }.configureEach { javadocJar ->
                 javadocJar.duplicatesStrategy = DuplicatesStrategy.WARN
-                javadocJar.from(project.tasks.withType<DokkaGenerateTask>().matching { "Publication" in it.name })
                 javadocJar.from(
-                    project.tasks.withType<DokkaTask>().matching { it.name.contains("html", ignoreCase = true) },
+                    project.tasks.withType<DokkaGenerateTask>()
+                        .matching { "Publication" in it.name },
+                )
+                javadocJar.from(
+                    project.tasks.withType<DokkaGenerateTask>()
+                        .matching { it.name.contains("html", ignoreCase = true) },
                 )
             }
         }

--- a/src/test/resources/org/danilopianini/gradle/test/ktmultiplatform/gradle.properties
+++ b/src/test/resources/org/danilopianini/gradle/test/ktmultiplatform/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.native.ignoreDisabledTargets=true
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/src/test/resources/org/danilopianini/gradle/test/ktmultiplatform/test.yaml
+++ b/src/test/resources/org/danilopianini/gradle/test/ktmultiplatform/test.yaml
@@ -10,17 +10,17 @@ tests:
     expectation:
       outcomes:
         success: *tasks
-  - description: "dokkaHtml works"
+  - description: "dokkaGeneratePublicationHtml works"
     configuration:
       tasks:
-        - dokkaHtml
+        - dokkaGeneratePublicationHtml
       options:
         - '--stacktrace'
     expectation:
       outcomes:
         success:
-          - dokkaHtml
-  - description: "javadocJar should rely on dokkaHtml instead of dokkaJavadoc"
+          - dokkaGeneratePublicationHtml
+  - description: "javadocJar should rely on dokkaGeneratePublicationHtml instead of dokkaJavadoc"
     configuration:
       tasks:
         - javadocJar
@@ -30,7 +30,7 @@ tests:
     expectation:
       outcomes:
         success:
-          - dokkaHtml
+          - dokkaGeneratePublicationHtml
         notExecuted:
           - dokkaJavadoc
       output:


### PR DESCRIPTION
## Dokka V2 Changes

The new version of [Dokka V2](https://kotlinlang.org/docs/dokka-migration.html) introduces several updates, including a change in the task name used to generate documentation.

In Dokka V2, the documentation is generated using the [dokkaGenerate](https://kotlinlang.org/docs/dokka-migration.html#generate-documentation-with-the-updated-task) task.
By default, Dokka V2 outputs HTML documentation.

However, it is now possible to configure Dokka V2 to generate documentation in HTML, Javadoc, or both formats simultaneously.
When both the HTML and Javadoc plugins are applied, Dokka V2 creates multiple tasks—for example, dokkaGeneratePublicationHtml and dokkaGeneratePublicationJavadoc.

To handle this scenario correctly, this PR updates the plugin logic to prioritize the dokkaGeneratePublicationHtml task when both plugins are present.

See the [official Dokka migration guide about documentation output format﻿](https://kotlinlang.org/docs/dokka-migration.html#select-documentation-output-format) for the full table of task names and output formats.

⸻

 ### Test Updates

The expected test output has been updated accordingly to reflect Dokka V2’s new task names and behavior.
