### PR TITLE
docs: add repository agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+## Scope
+These instructions apply to the entire repository.
+
+## Project Summary
+- This repository contains the Gradle plugin `org.danilopianini.publish-on-central`.
+- Main implementation lives under `src/main/kotlin/org/danilopianini/gradle/mavencentral`.
+- The codebase is Kotlin-based and built with Gradle Kotlin DSL.
+- The plugin targets Maven Central Portal publishing. For historical support boundaries and current publishing behavior, check `README.md` and the Gradle build files instead of assuming old Nexus/OSSRH flows still apply.
+
+## Repository Layout
+- Plugin entry point: `src/main/kotlin/org/danilopianini/gradle/mavencentral/PublishOnCentral.kt`
+- Portal-specific publishing code: `src/main/kotlin/org/danilopianini/gradle/mavencentral/portal`
+- Custom tasks: `src/main/kotlin/org/danilopianini/gradle/mavencentral/tasks`
+- Main automated tests: `src/test/kotlin/org/danilopianini/gradle/test/Tests.kt`
+- Test fixtures for Gradle TestKit scenarios: `src/test/resources/org/danilopianini/gradle/test/**`
+- CI workflows: `.github/workflows`
+
+## Working Rules
+- Preserve the current Gradle Kotlin DSL style and existing naming patterns.
+- Keep changes narrowly scoped. Avoid broad refactors unless the task requires them.
+- Do not edit generated build output under `build/`.
+- Assume the working tree may contain user changes. Never revert unrelated modifications.
+- Prefer ASCII in new files unless the file already uses non-ASCII content.
+
+## Build And Test
+- Preferred validation command after changes: `./gradlew build`
+- Use `./gradlew build` as the default check that the project still works after modifications.
+- If you change build logic, plugin wiring, publication setup, or task registration, consider running additional focused verification commands only if `build` is insufficient to cover the change.
+- Tests are primarily Gradle TestKit integration tests driven by fixture projects under `src/test/resources/org/danilopianini/gradle/test/`.
+- When adding coverage for a new scenario, prefer adding or extending a fixture project plus a TestKit-backed test instead of only adding a narrow unit test.
+- Test output is intentionally verbose; do not “simplify” logging unless explicitly requested.
+
+## Toolchain Expectations
+- Java toolchains are managed via Gradle. Compilation is configured for Java 17.
+- Java, Gradle plugin, and other dependency versions should be retrieved from `build.gradle.kts`, `settings.gradle.kts`, and the Gradle version catalog files under `gradle/`.
+- Node and npm version requirements should be retrieved from `package.json`.
+- The repository uses pre-commit hooks configured in `settings.gradle.kts`:
+  - commit messages must follow conventional commits
+  - `ktlintCheck` and `detekt` run in pre-commit
+
+## Release And Publishing
+- Releases are driven by `semantic-release` via `release.config.mjs`.
+- Publishing includes:
+  - Gradle Plugin Portal via `publishPlugins`
+  - Maven Central Portal via `publishAllPublicationsToProjectLocalRepository`, `zipMavenCentralPortalPublication`, and `releaseMavenCentralPortalPublication`
+  - GitHub Packages as a secondary target
+- Do not change release automation, tags, or publishing credentials flow unless the task is specifically about release infrastructure.
+- Publishing and signing rely on environment variables or Gradle properties; never hardcode secrets.
+
+## Change Guidance
+- For plugin behavior changes, update both implementation and the relevant fixture-based tests.
+- For documentation changes affecting usage or publishing flow, keep `README.md` aligned with the actual tasks and credential names.
+- If changing task names, publication names, or credential lookup behavior, treat that as a breaking or potentially breaking change and verify all references in code, tests, README, and workflows.
+
+## Things To Check Before Finishing
+- Relevant Gradle tests pass.
+- New behavior is covered by tests when practical.
+- README and workflow references remain accurate if user-facing behavior changed.
+- No accidental edits were made to generated files or unrelated user changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ These instructions apply to the entire repository.
 - If you change build logic, plugin wiring, publication setup, or task registration, consider running additional focused verification commands only if `build` is insufficient to cover the change.
 - Tests are primarily Gradle TestKit integration tests driven by fixture projects under `src/test/resources/org/danilopianini/gradle/test/`.
 - When adding coverage for a new scenario, prefer adding or extending a fixture project plus a TestKit-backed test instead of only adding a narrow unit test.
-- Test output is intentionally verbose; do not “simplify” logging unless explicitly requested.
+- Test output is intentionally verbose; do not "simplify" logging unless explicitly requested.
 
 ## Toolchain Expectations
 - Java toolchains are managed via Gradle. Compilation is configured for Java 17.


### PR DESCRIPTION
## Summary
- add a repository-local  with guidance for agents working in this plugin
- document the main source layout, release workflow, and validation expectations
- make 
> Configure project :
    
    Thank you for enabling Dokka Gradle plugin V2!
    To learn about migrating read the migration guide https://kotl.in/dokka-gradle-migration
    
    We would appreciate your feedback!
     - Please report any feedback or problems https://kotl.in/dokka-issues
     - Chat with the community visit #dokka in https://kotlinlang.slack.com/ (To sign up visit https://kotl.in/slack)
    
    You can suppress this message by adding
        org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
    to your project's `gradle.properties` file.
    

> Task :checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :compileKotlin UP-TO-DATE
> Task :compileJava NO-SOURCE
> Task :pluginDescriptors UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :jar
> Task :javadoc SKIPPED
> Task :sourcesJar
> Task :cpdCheck SKIPPED
> Task :cpdKotlinCheck UP-TO-DATE
> Task :generateDefaultDetektConfiguration UP-TO-DATE
> Task :detekt UP-TO-DATE
> Task :detektMain UP-TO-DATE
> Task :loadKtlintReporters UP-TO-DATE
> Task :runKtlintCheckOverKotlinScripts UP-TO-DATE
> Task :ktlintKotlinScriptCheck UP-TO-DATE
> Task :runKtlintCheckOverMainSourceSet UP-TO-DATE
> Task :ktlintMainSourceSetCheck UP-TO-DATE
> Task :runKtlintCheckOverTestSourceSet UP-TO-DATE
> Task :ktlintTestSourceSetCheck UP-TO-DATE
> Task :pluginUnderTestMetadata UP-TO-DATE
> Task :processTestResources

> Task :compileTestKotlin FAILED

> Task :validatePlugins
> Task :reportMergeDetekt UP-TO-DATE
> Task :dokkaGeneratePublicationHtml

> Task :logLinkDokkaGeneratePublicationHtml
Generated Dokka HTML publication: http://localhost:63342/publish-on-central/build/dokka/html/index.html

[Incubating] Problems report is available at: file:///home/danysk/LocalProjects/publish-on-central/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.3.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
23 actionable tasks: 7 executed, 16 up-to-date

Publishing Build Scan to Develocity...
https://gradle.com/s/evu6krfjrb72c the default post-change verification command and point version lookup to repository files instead of hardcoded values

## Validation
- the commit hook passed (, )
- a full 
> Configure project :
    
    Thank you for enabling Dokka Gradle plugin V2!
    To learn about migrating read the migration guide https://kotl.in/dokka-gradle-migration
    
    We would appreciate your feedback!
     - Please report any feedback or problems https://kotl.in/dokka-issues
     - Chat with the community visit #dokka in https://kotlinlang.slack.com/ (To sign up visit https://kotl.in/slack)
    
    You can suppress this message by adding
        org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
    to your project's `gradle.properties` file.
    

> Task :checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :compileKotlin UP-TO-DATE
> Task :compileJava NO-SOURCE
> Task :pluginDescriptors UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :jar UP-TO-DATE
> Task :dokkaGeneratePublicationHtml UP-TO-DATE

> Task :logLinkDokkaGeneratePublicationHtml
Generated Dokka HTML publication: http://localhost:63342/publish-on-central/build/dokka/html/index.html

> Task :javadoc SKIPPED
> Task :javadocJar
> Task :sourcesJar UP-TO-DATE
> Task :assemble
> Task :cpdCheck SKIPPED
> Task :cpdKotlinCheck UP-TO-DATE
> Task :generateDefaultDetektConfiguration UP-TO-DATE
> Task :detekt UP-TO-DATE
> Task :detektMain UP-TO-DATE
> Task :loadKtlintReporters UP-TO-DATE
> Task :runKtlintCheckOverKotlinScripts UP-TO-DATE
> Task :ktlintKotlinScriptCheck UP-TO-DATE
> Task :runKtlintCheckOverMainSourceSet UP-TO-DATE
> Task :ktlintMainSourceSetCheck UP-TO-DATE
> Task :runKtlintCheckOverTestSourceSet UP-TO-DATE
> Task :ktlintTestSourceSetCheck UP-TO-DATE
> Task :pluginUnderTestMetadata UP-TO-DATE
> Task :processTestResources UP-TO-DATE
> Task :validatePlugins UP-TO-DATE

> Task :compileTestKotlin FAILED

> Task :reportMergeDetekt UP-TO-DATE

[Incubating] Problems report is available at: file:///home/danysk/LocalProjects/publish-on-central/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.3.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
24 actionable tasks: 3 executed, 21 up-to-date

Publishing Build Scan to Develocity...
https://gradle.com/s/dkyg7a3nlvtjy in this worktree is currently blocked by unrelated untracked local test sources under 
