### PR TITLE
fix: prefer Dokka v2 when enabled

### DIFF
--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/PublishOnCentral.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/PublishOnCentral.kt
@@ -127,12 +127,16 @@ class PublishOnCentral : Plugin<Project> {
             project.tasks.withType<Javadoc>().configureEach { it.enabled = false }
             project.tasks.withType<Jar>().matching { "javadoc" in it.name }.configureEach { javadocJar ->
                 javadocJar.duplicatesStrategy = DuplicatesStrategy.WARN
-                val dokkaV2HtmlTasks = project.dokkaV2HtmlTasks()
-                if (dokkaV2HtmlTasks.isNotEmpty()) {
-                    javadocJar.from(dokkaV2HtmlTasks)
-                } else {
-                    javadocJar.from(project.dokkaV1HtmlTasks())
-                }
+                javadocJar.from(
+                    project.provider {
+                        val dokkaV2HtmlTasks = project.dokkaV2HtmlTasks()
+                        if (dokkaV2HtmlTasks.names.isNotEmpty()) {
+                            dokkaV2HtmlTasks
+                        } else {
+                            project.dokkaV1HtmlTasks()
+                        }
+                    },
+                )
             }
         }
     }

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/PublishOnCentral.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/PublishOnCentral.kt
@@ -41,6 +41,15 @@ class PublishOnCentral : Plugin<Project> {
         private const val PUBLICATION_NAME = "OSSRH"
 
         private fun Project.javadocJarTask() = project.registerTaskIfNeeded("javadocJar", JavadocJar::class)
+
+        private fun Project.dokkaV2HtmlTasks() = tasks.withType<DokkaGenerateTask>().matching {
+            it.name.contains("publication", ignoreCase = true) &&
+                it.name.contains("html", ignoreCase = true)
+        }
+
+        private fun Project.dokkaV1HtmlTasks() = tasks.withType<DokkaTask>().matching {
+            it.name.contains("html", ignoreCase = true)
+        }
     }
 
     override fun apply(project: Project) {
@@ -118,10 +127,12 @@ class PublishOnCentral : Plugin<Project> {
             project.tasks.withType<Javadoc>().configureEach { it.enabled = false }
             project.tasks.withType<Jar>().matching { "javadoc" in it.name }.configureEach { javadocJar ->
                 javadocJar.duplicatesStrategy = DuplicatesStrategy.WARN
-                javadocJar.from(project.tasks.withType<DokkaGenerateTask>().matching { "Publication" in it.name })
-                javadocJar.from(
-                    project.tasks.withType<DokkaTask>().matching { it.name.contains("html", ignoreCase = true) },
-                )
+                val dokkaV2HtmlTasks = project.dokkaV2HtmlTasks()
+                if (dokkaV2HtmlTasks.isNotEmpty()) {
+                    javadocJar.from(dokkaV2HtmlTasks)
+                } else {
+                    javadocJar.from(project.dokkaV1HtmlTasks())
+                }
             }
         }
     }

--- a/src/test/resources/org/danilopianini/gradle/test/ktmultiplatform/gradle.properties
+++ b/src/test/resources/org/danilopianini/gradle/test/ktmultiplatform/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.native.ignoreDisabledTargets=true
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/src/test/resources/org/danilopianini/gradle/test/ktmultiplatform/test.yaml
+++ b/src/test/resources/org/danilopianini/gradle/test/ktmultiplatform/test.yaml
@@ -10,17 +10,17 @@ tests:
     expectation:
       outcomes:
         success: *tasks
-  - description: "dokkaHtml works"
+  - description: "dokkaGeneratePublicationHtml works"
     configuration:
       tasks:
-        - dokkaHtml
+        - dokkaGeneratePublicationHtml
       options:
         - '--stacktrace'
     expectation:
       outcomes:
         success:
-          - dokkaHtml
-  - description: "javadocJar should rely on dokkaHtml instead of dokkaJavadoc"
+          - dokkaGeneratePublicationHtml
+  - description: "javadocJar should rely on dokkaGeneratePublicationHtml when Dokka v2 is enabled"
     configuration:
       tasks:
         - javadocJar
@@ -30,9 +30,11 @@ tests:
     expectation:
       outcomes:
         success:
-          - dokkaHtml
+          - dokkaGeneratePublicationHtml
         notExecuted:
           - dokkaJavadoc
+          - dokkaGeneratePublicationJavadoc
+          - dokkaHtml
       output:
         contains:
           - "Dokka plugin found, hence javadocJar will be configured"


### PR DESCRIPTION
## Summary
- use Dokka v2 publication HTML tasks when Dokka v2 is available and enabled
- fall back to Dokka v1 HTML tasks only when Dokka v2 HTML tasks are not present
- update the multiplatform fixture to enable Dokka v2 helpers and assert that both Dokka v1 and Dokka v2 Javadoc tasks are ignored

## Relation to #1529
This addresses the same problem as #1529, but narrows the selection logic so Dokka v2 Javadoc output is not pulled into the javadoc jar when Dokka v2 HTML is available.

## Validation
- pre-commit checks passed: detekt, ktlintCheck
- a clean-clone ./gradlew build reached the TestKit suite, but that clone setup hit separate plugin-resolution failures in fixture builds that are not specific to this change
