### PR TITLE
chore(core-deps): update gradle to v9.4.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/tasks/JarWithClassifier.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/tasks/JarWithClassifier.kt
@@ -2,11 +2,13 @@ package org.danilopianini.gradle.mavencentral.tasks
 
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * A [Jar] task with the specified classifier, and adopting the duplicate strategy
  * [org.gradle.api.file.DuplicatesStrategy.WARN].
  */
+@DisableCachingByDefault(because = "Caching behavior has not been reviewed for this custom Jar task yet")
 abstract class JarWithClassifier(classifier: String) : Jar() {
     init {
         archiveClassifier.set(classifier)

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/tasks/JavadocJar.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/tasks/JavadocJar.kt
@@ -1,8 +1,11 @@
 package org.danilopianini.gradle.mavencentral.tasks
 
+import org.gradle.work.DisableCachingByDefault
+
 /**
  * A task generating a Jar file with the Javadoc.
  */
+@DisableCachingByDefault(because = "Caching behavior depends on documentation task inputs configured at runtime")
 abstract class JavadocJar : JarWithClassifier("javadoc") {
     init {
         description = "Assembles a jar archive containing the javadoc documentation"

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/tasks/ZipMavenCentralPortalPublication.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/tasks/ZipMavenCentralPortalPublication.kt
@@ -6,10 +6,14 @@ import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.publish.plugins.PublishingPlugin
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.kotlin.dsl.withType
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * A Zip task that creates a zip file containing the local Maven repository.
  */
+@DisableCachingByDefault(
+    because = "The archive content depends on publishing outputs produced during the current build",
+)
 abstract class ZipMavenCentralPortalPublication @Inject constructor() : Zip() {
     init {
         group = PublishingPlugin.PUBLISH_TASK_GROUP


### PR DESCRIPTION
## Summary
- update the Gradle wrapper to 9.4.1 with the official binary distribution checksum
- add explicit task caching annotations required by Gradle 9.4.1 plugin validation
- keep the change scoped to wrapper and task-type compatibility fixes

## Validation
- ./gradlew build
