### PR TITLE
chore(deps): update plugin kotlin-qa to v1.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gitSemVer = "org.danilopianini.git-sensitive-semantic-versioning:7.0.16"
 gradlePluginPublish = "com.gradle.plugin-publish:2.1.1"
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-qa = "org.danilopianini.gradle-kotlin-qa:0.101.1"
+kotlin-qa = "org.danilopianini.gradle-kotlin-qa:1.4.0"
 multiJvmTesting = "org.danilopianini.multi-jvm-test-plugin:4.1.2"
 publishOnCentral = "org.danilopianini.publish-on-central:9.1.14"
 taskTree = "com.dorongold.task-tree:4.0.1"

--- a/src/main/kotlin/org/danilopianini/gradle/mavencentral/tasks/JarWithClassifier.kt
+++ b/src/main/kotlin/org/danilopianini/gradle/mavencentral/tasks/JarWithClassifier.kt
@@ -9,6 +9,8 @@ import org.gradle.work.DisableCachingByDefault
  * [org.gradle.api.file.DuplicatesStrategy.WARN].
  */
 @DisableCachingByDefault(because = "Caching behavior has not been reviewed for this custom Jar task yet")
+// Gradle task types intentionally remain abstract so Gradle can generate decorated task implementations.
+@Suppress("detekt.AbstractClassCanBeConcreteClass")
 abstract class JarWithClassifier(classifier: String) : Jar() {
     init {
         archiveClassifier.set(classifier)


### PR DESCRIPTION
## Summary
- update the kotlin-qa plugin to 1.4.0 in the version catalog
- keep  abstract because it is a Gradle task base type
- add an explicit justification comment for the detekt suppression required by the stricter kotlin-qa rule set

## Validation
- ./gradlew build
